### PR TITLE
Created FieldSetMetadata.cls

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ A lightweight library of Apex classes for Salesforce that provide easy access to
             if(new SObjectMetadata('MyCustomObject__c').isDeletable == false) return;
 
             //Otherwise, delete the record
-            myRecord myRecord.MyCustomField__c;
+            delete myRecord.MyCustomField__c;
         }
 
     }

--- a/README.md
+++ b/README.md
@@ -10,12 +10,12 @@ A lightweight library of Apex classes for Salesforce that provide easy access to
 ## SObjectMetadata.cls
 * Contains metadata information for the specified SObject. There are 2 ways to create an instance of SObjectMetadata
 
-    By passing the SObject's API name as a string in the constructor
+    1. By passing the SObject's API name as a string in the constructor
     ```
     new SObjectMetadata('Account')
     ```
 
-    By passing the SObject Type in the constructor
+    2. By passing the SObject Type in the constructor
     ```
     new SObjectMetadata(Schema.Account.SObjectType)`
     ```
@@ -40,12 +40,12 @@ A lightweight library of Apex classes for Salesforce that provide easy access to
 ## FieldMetadata.cls
 * Contains metadata information for the specified field. There are 2 ways to create an instance of FieldMetadata
 
-    By passing the SObject's API name and the field's API name as strings in the constructor
+    1. By passing the SObject's API name and the field's API name as strings in the constructor
     ```
     new FieldMetadata('Account', 'Type')
     ```
 
-    By passing the SObject Type and the SObject Field in the constructor
+    2. By passing the SObject Type and the SObject Field in the constructor
     ```
     new FieldMetadata(Schema.Account.SObjectType, Schema.Account.Type)
     ```
@@ -65,4 +65,17 @@ A lightweight library of Apex classes for Salesforce that provide easy access to
         }
 
     }
+    ```
+
+## FieldSetMetadata.cls
+* Contains metadata information for the specified field set, as well as the field set's SObject and the field metadata for each field set member. There are 2 ways to create an instance of FieldMetadata
+
+    1. By passing the SObject's API name and the field set's API name as strings in the constructor
+    ```
+    new FieldSetMetadata('Lead', 'MyFieldSet')
+    ```
+
+    2. By passing the FieldSet in the constructor
+    ```
+    new FieldSetMetadata(SObjectType.Lead.FieldSets.MyFieldSet);
     ```

--- a/src/classes/FieldMetadata.cls
+++ b/src/classes/FieldMetadata.cls
@@ -6,7 +6,10 @@ public class FieldMetadata {
 
     // Aura-enabled member variables
     @AuraEnabled public Integer byteLength                           {get; private set;}
+    @AuraEnabled public Object defaultValue                          {get; private set;}
     @AuraEnabled public Integer digits                               {get; private set;}
+    @AuraEnabled public String displayType                           {get; private set;}
+    @AuraEnabled public String inlineHelpText                        {get; private set;}
     @AuraEnabled public Boolean isAccessible                         {get; private set;}
     @AuraEnabled public Boolean isAutoNumber                         {get; private set;}
     @AuraEnabled public Boolean isCalculated                         {get; private set;}
@@ -21,15 +24,12 @@ public class FieldMetadata {
     @AuraEnabled public Boolean isRequired                           {get; private set;}
     @AuraEnabled public Boolean isSortable                           {get; private set;}
     @AuraEnabled public Boolean isUpdateable                         {get; private set;}
-    @AuraEnabled public Integer maxLength                            {get; private set;}
-    @AuraEnabled public List<PicklistEntryMetadata> picklistOptions  {get; private set;}
-    @AuraEnabled public Object defaultValue                          {get; private set;}
-    @AuraEnabled public String displayType                           {get; private set;}
-    @AuraEnabled public String inlineHelpText                        {get; private set;}
     @AuraEnabled public String label                                 {get; private set;}
     @AuraEnabled public String localName                             {get; private set;}
+    @AuraEnabled public Integer maxLength                            {get; private set;}
     @AuraEnabled public String name                                  {get; private set;}
     @AuraEnabled public String namespace                             {get; private set;}
+    @AuraEnabled public List<PicklistEntryMetadata> picklistOptions  {get; private set;}
     @AuraEnabled public Integer precision                            {get; private set;}
     @AuraEnabled public String relationshipName                      {get; private set;}
     @AuraEnabled public Integer relationshipOrder                    {get; private set;}

--- a/src/classes/FieldMetadata.cls
+++ b/src/classes/FieldMetadata.cls
@@ -2,7 +2,7 @@
 * This file is part of the SimpleMetadata project, released under the MIT License.              *
 * See LICENSE file or go to https://github.com/jongpie/SimpleMetadata for full license details.  *
 *************************************************************************************************/
-public class FieldMetadata {
+public virtual class FieldMetadata {
 
     // Aura-enabled member variables
     @AuraEnabled public Integer byteLength                           {get; private set;}
@@ -124,7 +124,7 @@ public class FieldMetadata {
         }
     }
 
-    public class PicklistEntryMetadata {
+    public virtual class PicklistEntryMetadata {
 
         // Aura-enabled member variables
         @AuraEnabled public Boolean isDefaultValue {get; private set;}

--- a/src/classes/FieldMetadata.cls
+++ b/src/classes/FieldMetadata.cls
@@ -1,5 +1,5 @@
 /*************************************************************************************************
-* This file is part of the SimpleMetadata project, released under the MIT License.              *
+* This file is part of the SimpleMetadata project, released under the MIT License.               *
 * See LICENSE file or go to https://github.com/jongpie/SimpleMetadata for full license details.  *
 *************************************************************************************************/
 public virtual class FieldMetadata {

--- a/src/classes/FieldMetadata.cls
+++ b/src/classes/FieldMetadata.cls
@@ -97,7 +97,7 @@ public class FieldMetadata {
         return this.sobjectField;
     }
 
-    public String serialize() {
+    public override String toString() {
         return JSON.serialize(this);
     }
 

--- a/src/classes/FieldSetMetadata.cls
+++ b/src/classes/FieldSetMetadata.cls
@@ -8,6 +8,7 @@ public virtual class FieldSetMetadata {
     @AuraEnabled String description                  {get; private set;}
     @AuraEnabled List<FieldSetMemberMetadata> fields {get; private set;}
     @AuraEnabled String label                        {get; private set;}
+    @AuraEnabled String localName                    {get; private set;}
     @AuraEnabled String name                         {get; private set;}
     @AuraEnabled String namespace                    {get; private set;}
     @AuraEnabled String sobjectName                  {get; private set;}
@@ -30,6 +31,7 @@ public virtual class FieldSetMetadata {
         this.label       = this.getFieldSet().getLabel();
         this.namespace   = this.getFieldSet().getNamespace();
 
+        this.setLocalName();
         this.setFields();
     }
 
@@ -44,7 +46,14 @@ public virtual class FieldSetMetadata {
         return JSON.serialize(this);
     }
 
+    private void setLocalName() {
+        Integer localNameIndex = this.name.replace('__c', '').indexOf('__');
+        // Add to to the localNameIndex to compensate for the '__' part of the namespace
+        this.localName = localNameIndex < 0 ? null : this.name.substring(localNameIndex + 2, this.name.length());
+    }
+
     private void setFields() {
+        this.fields = new List<FieldSetMemberMetadata>();
         for(Schema.FieldSetMember fieldSetMember : fieldSet.getFields()) {
             FieldSetMemberMetadata fieldSetMemberMetadata = new FieldSetMemberMetadata(sobjectName, fieldSetMember);
 
@@ -57,7 +66,6 @@ public virtual class FieldSetMetadata {
         // Aura-enabled member variables
         @AuraEnabled public String displayType          {get; private set;}
         @AuraEnabled public FieldMetadata fieldMetadata {get; private set;}
-        @AuraEnabled public String fieldName            {get; private set;}
         @AuraEnabled public String fieldPath            {get; private set;}
         @AuraEnabled public Boolean isDBRequired        {get; private set;}
         @AuraEnabled public Boolean isRequired          {get; private set;}
@@ -67,18 +75,45 @@ public virtual class FieldSetMetadata {
         // Private variables - marked as transient so they aren't included during JSON.serialize()
         private transient Schema.FieldSetMember fieldSetMember;
 
-        private FieldSetMemberMetadata(String sobjectName, String fieldName, Schema.FieldSetMember fieldSetMember) {
+        private FieldSetMemberMetadata(String sobjectName, Schema.FieldSetMember fieldSetMember) {
             this.sobjectName    = sobjectName;
-            this.fieldName      = fieldName;
             this.fieldSetMember = fieldSetMember;
-
-            this.fieldMetadata = new FieldMetadata(sobjectName, fieldName);
 
             this.displayType  = this.fieldSetMember.getType().name();
             this.fieldPath    = this.fieldSetMember.getFieldPath();
             this.isDBRequired = this.fieldSetMember.getDBRequired();
             this.isRequired   = this.fieldSetMember.getRequired();
             this.label        = this.fieldSetMember.getLabel();
+
+            this.setFieldMetadata();
+        }
+
+        private void setFieldMetadata() {
+            List<String> fieldChain = this.fieldPath.split('\\.');
+
+            if(fieldChain.size() == 0) return;
+
+            Schema.SObjectType currentFieldSObjectType = Schema.getGlobalDescribe().get(this.sobjectName);
+            String currentFieldSObjectName = this.sobjectName;
+            String currentFieldName;
+
+            for(Integer i = 0; i < fieldChain.size(); i++) {
+                currentFieldName = fieldChain[i];
+
+                for(Schema.SObjectField sobjectField : Schema.getGlobalDescribe().get(currentFieldSObjectName).getDescribe().fields.getMap().values()) {
+                    DescribeFieldResult fieldDescribe = sobjectField.getDescribe();
+
+                    if(fieldDescribe.getRelationshipName() == currentFieldName && !fieldDescribe.getReferenceTo().isEmpty()) {
+                        currentFieldSObjectType = fieldDescribe.getReferenceTo()[0];
+                        currentFieldSObjectName = currentFieldSObjectType.getDescribe().getName();
+
+                        break;
+                    }
+
+                }
+
+                this.fieldMetadata = new FieldMetadata(currentFieldSObjectName, currentFieldName);
+            }
         }
 
     }

--- a/src/classes/FieldSetMetadata.cls
+++ b/src/classes/FieldSetMetadata.cls
@@ -52,12 +52,12 @@ public with sharing class FieldSetMetadata {
     public class FieldSetMemberMetadata {
 
         // Aura-enabled member variables
-        @AuraEnabled public Boolean isDBRequired        {get; private set;}
-        @AuraEnabled public Boolean isRequired          {get; private set;}
-        @AuraEnabled public FieldMetadata fieldMetadata {get; private set;}
         @AuraEnabled public String displayType          {get; private set;}
+        @AuraEnabled public FieldMetadata fieldMetadata {get; private set;}
         @AuraEnabled public String fieldName            {get; private set;}
         @AuraEnabled public String fieldPath            {get; private set;}
+        @AuraEnabled public Boolean isDBRequired        {get; private set;}
+        @AuraEnabled public Boolean isRequired          {get; private set;}
         @AuraEnabled public String label                {get; private set;}
         @AuraEnabled public String sobjectName          {get; private set;}
 

--- a/src/classes/FieldSetMetadata.cls
+++ b/src/classes/FieldSetMetadata.cls
@@ -1,5 +1,5 @@
 /*************************************************************************************************
-* This file is part of the SimpleMetadata project, released under the MIT License.              *
+* This file is part of the SimpleMetadata project, released under the MIT License.               *
 * See LICENSE file or go to https://github.com/jongpie/SimpleMetadata for full license details.  *
 *************************************************************************************************/
 public virtual class FieldSetMetadata {

--- a/src/classes/FieldSetMetadata.cls
+++ b/src/classes/FieldSetMetadata.cls
@@ -1,0 +1,84 @@
+/*************************************************************************************************
+* This file is part of the SimpleMetadata project, released under the MIT License.              *
+* See LICENSE file or go to https://github.com/jongpie/SimpleMetadata for full license details.  *
+*************************************************************************************************/
+public with sharing class FieldSetMetadata {
+
+    // Aura-enabled member variables
+    @AuraEnabled String description                  {get; private set;}
+    @AuraEnabled List<FieldSetMemberMetadata> fields {get; private set;}
+    @AuraEnabled String label                        {get; private set;}
+    @AuraEnabled String name                         {get; private set;}
+    @AuraEnabled String namespace                    {get; private set;}
+    @AuraEnabled String sobjectName                  {get; private set;}
+    @AuraEnabled SObjectMetadata sobjectMetadata     {get; private set;}
+
+    // Private variables - marked as transient so they aren't included during JSON.serialize()
+    private transient Schema.FieldSet fieldSet;
+
+    public FieldSetMetadata(String sobjectName, String fieldSetName) {
+        this.sobjectName = sobjectName;
+        this.name        = fieldSetName;
+
+        this.sobjectMetadata = new SObjectMetadata(sobjectName);
+
+        this.description = this.getFieldSet().getDescription();
+        this.label       = this.getFieldSet().getLabel();
+        this.namespace   = this.getFieldSet().getNamespace();
+
+        this.setFields();
+    }
+
+    public Schema.FieldSet getFieldSet() {
+        // If a JSON object is deserialized into an instance of this class, private variables are null, so set them when needed
+        if(this.fieldSet == null) this.fieldSet = this.sobjectMetadata.getDescribe().fieldSets.getMap().get(this.name);
+
+        return this.fieldSet;
+    }
+
+    public String serialize() {
+        return JSON.serialize(this);
+    }
+
+
+    private void setFields() {
+        for(Schema.FieldSetMember fieldSetMember : fieldSet.getFields()) {
+            String fieldName = fieldSetMember.getFieldPath();
+            FieldSetMemberMetadata fieldSetMemberMetadata = new FieldSetMemberMetadata(sobjectName, fieldName, fieldSetMember);
+
+            this.fields.add(fieldSetMemberMetadata);
+        }
+    }
+
+    public class FieldSetMemberMetadata {
+
+        // Aura-enabled member variables
+        @AuraEnabled public Boolean isDBRequired        {get; private set;}
+        @AuraEnabled public Boolean isRequired          {get; private set;}
+        @AuraEnabled public FieldMetadata fieldMetadata {get; private set;}
+        @AuraEnabled public String fieldPath            {get; private set;}
+        @AuraEnabled public String fieldName            {get; private set;}
+        @AuraEnabled public String label                {get; private set;}
+        @AuraEnabled public String sobjectName          {get; private set;}
+        @AuraEnabled public String displayType          {get; private set;}
+
+        // Private variables - marked as transient so they aren't included during JSON.serialize()
+        private transient Schema.FieldSetMember fieldSetMember;
+
+        private FieldSetMemberMetadata(String sobjectName, String fieldName, Schema.FieldSetMember fieldSetMember) {
+            this.sobjectName    = sobjectName;
+            this.fieldName      = fieldName;
+            this.fieldSetMember = fieldSetMember;
+
+            this.fieldMetadata = new FieldMetadata(sobjectName, fieldName);
+
+            this.fieldPath    = this.fieldSetMember.getFieldPath();
+            this.isDBRequired = this.fieldSetMember.getDBRequired();
+            this.isRequired   = this.fieldSetMember.getRequired();
+            this.label        = this.fieldSetMember.getLabel();
+            this.displayType  = this.fieldSetMember.getType().name();
+        }
+
+    }
+
+}

--- a/src/classes/FieldSetMetadata.cls
+++ b/src/classes/FieldSetMetadata.cls
@@ -36,7 +36,7 @@ public with sharing class FieldSetMetadata {
         return this.fieldSet;
     }
 
-    public String serialize() {
+    public override String toString() {
         return JSON.serialize(this);
     }
 

--- a/src/classes/FieldSetMetadata.cls
+++ b/src/classes/FieldSetMetadata.cls
@@ -40,7 +40,6 @@ public with sharing class FieldSetMetadata {
         return JSON.serialize(this);
     }
 
-
     private void setFields() {
         for(Schema.FieldSetMember fieldSetMember : fieldSet.getFields()) {
             String fieldName = fieldSetMember.getFieldPath();

--- a/src/classes/FieldSetMetadata.cls
+++ b/src/classes/FieldSetMetadata.cls
@@ -55,11 +55,11 @@ public with sharing class FieldSetMetadata {
         @AuraEnabled public Boolean isDBRequired        {get; private set;}
         @AuraEnabled public Boolean isRequired          {get; private set;}
         @AuraEnabled public FieldMetadata fieldMetadata {get; private set;}
-        @AuraEnabled public String fieldPath            {get; private set;}
+        @AuraEnabled public String displayType          {get; private set;}
         @AuraEnabled public String fieldName            {get; private set;}
+        @AuraEnabled public String fieldPath            {get; private set;}
         @AuraEnabled public String label                {get; private set;}
         @AuraEnabled public String sobjectName          {get; private set;}
-        @AuraEnabled public String displayType          {get; private set;}
 
         // Private variables - marked as transient so they aren't included during JSON.serialize()
         private transient Schema.FieldSetMember fieldSetMember;
@@ -71,11 +71,11 @@ public with sharing class FieldSetMetadata {
 
             this.fieldMetadata = new FieldMetadata(sobjectName, fieldName);
 
+            this.displayType  = this.fieldSetMember.getType().name();
             this.fieldPath    = this.fieldSetMember.getFieldPath();
             this.isDBRequired = this.fieldSetMember.getDBRequired();
             this.isRequired   = this.fieldSetMember.getRequired();
             this.label        = this.fieldSetMember.getLabel();
-            this.displayType  = this.fieldSetMember.getType().name();
         }
 
     }

--- a/src/classes/FieldSetMetadata.cls
+++ b/src/classes/FieldSetMetadata.cls
@@ -5,14 +5,14 @@
 public virtual class FieldSetMetadata {
 
     // Aura-enabled member variables
-    @AuraEnabled String description                  {get; private set;}
-    @AuraEnabled List<FieldSetMemberMetadata> fields {get; private set;}
-    @AuraEnabled String label                        {get; private set;}
-    @AuraEnabled String localName                    {get; private set;}
-    @AuraEnabled String name                         {get; private set;}
-    @AuraEnabled String namespace                    {get; private set;}
-    @AuraEnabled String sobjectName                  {get; private set;}
-    @AuraEnabled SObjectMetadata sobjectMetadata     {get; private set;}
+    @AuraEnabled String description                           {get; private set;}
+    @AuraEnabled List<FieldSetMemberMetadata> fieldSetMembers {get; private set;}
+    @AuraEnabled String label                                 {get; private set;}
+    @AuraEnabled String localName                             {get; private set;}
+    @AuraEnabled String name                                  {get; private set;}
+    @AuraEnabled String namespace                             {get; private set;}
+    @AuraEnabled String sobjectName                           {get; private set;}
+    @AuraEnabled SObjectMetadata sobjectMetadata              {get; private set;}
 
     // Private variables - marked as transient so they aren't included during JSON.serialize()
     private transient Schema.FieldSet fieldSet;
@@ -53,11 +53,11 @@ public virtual class FieldSetMetadata {
     }
 
     private void setFields() {
-        this.fields = new List<FieldSetMemberMetadata>();
+        this.fieldSetMembers = new List<FieldSetMemberMetadata>();
         for(Schema.FieldSetMember fieldSetMember : fieldSet.getFields()) {
             FieldSetMemberMetadata fieldSetMemberMetadata = new FieldSetMemberMetadata(sobjectName, fieldSetMember);
 
-            this.fields.add(fieldSetMemberMetadata);
+            this.fieldSetMembers.add(fieldSetMemberMetadata);
         }
     }
 

--- a/src/classes/FieldSetMetadata.cls
+++ b/src/classes/FieldSetMetadata.cls
@@ -2,7 +2,7 @@
 * This file is part of the SimpleMetadata project, released under the MIT License.              *
 * See LICENSE file or go to https://github.com/jongpie/SimpleMetadata for full license details.  *
 *************************************************************************************************/
-public with sharing class FieldSetMetadata {
+public virtual class FieldSetMetadata {
 
     // Aura-enabled member variables
     @AuraEnabled String description                  {get; private set;}
@@ -15,6 +15,10 @@ public with sharing class FieldSetMetadata {
 
     // Private variables - marked as transient so they aren't included during JSON.serialize()
     private transient Schema.FieldSet fieldSet;
+
+    public FieldSetMetadata(Schema.FieldSet fieldSet) {
+        this(String.valueOf(fieldset.getSObjectType()), fieldSet.getName());
+    }
 
     public FieldSetMetadata(String sobjectName, String fieldSetName) {
         this.sobjectName = sobjectName;
@@ -42,14 +46,13 @@ public with sharing class FieldSetMetadata {
 
     private void setFields() {
         for(Schema.FieldSetMember fieldSetMember : fieldSet.getFields()) {
-            String fieldName = fieldSetMember.getFieldPath();
-            FieldSetMemberMetadata fieldSetMemberMetadata = new FieldSetMemberMetadata(sobjectName, fieldName, fieldSetMember);
+            FieldSetMemberMetadata fieldSetMemberMetadata = new FieldSetMemberMetadata(sobjectName, fieldSetMember);
 
             this.fields.add(fieldSetMemberMetadata);
         }
     }
 
-    public class FieldSetMemberMetadata {
+    public virtual class FieldSetMemberMetadata {
 
         // Aura-enabled member variables
         @AuraEnabled public String displayType          {get; private set;}

--- a/src/classes/FieldSetMetadata.cls-meta.xml
+++ b/src/classes/FieldSetMetadata.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>40.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/src/classes/FieldSetMetadata.cls-meta.xml
+++ b/src/classes/FieldSetMetadata.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>40.0</apiVersion>
+    <apiVersion>41.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/SObjectMetadata.cls
+++ b/src/classes/SObjectMetadata.cls
@@ -26,7 +26,7 @@ public virtual class SObjectMetadata {
     @AuraEnabled public String localName                     {get; private set;}
     @AuraEnabled public String name                          {get; private set;}
     @AuraEnabled public String nameField                     {get; private set;}
-    @AuraEnabled public String nameSpace                     {get; private set;}
+    @AuraEnabled public String namespace                     {get; private set;}
     @AuraEnabled public List<RecordTypeMetadata> recordTypes {get; private set;}
     @AuraEnabled public String tabIcon                       {get; private set;}
 

--- a/src/classes/SObjectMetadata.cls
+++ b/src/classes/SObjectMetadata.cls
@@ -78,7 +78,7 @@ public class SObjectMetadata {
         return this.sobjectType;
     }
 
-    public String serialize() {
+    public override String toString() {
         return JSON.serialize(this);
     }
 

--- a/src/classes/SObjectMetadata.cls
+++ b/src/classes/SObjectMetadata.cls
@@ -2,7 +2,7 @@
 * This file is part of the SimpleMetadata project, released under the MIT License.              *
 * See LICENSE file or go to https://github.com/jongpie/SimpleMetadata for full license details.  *
 *************************************************************************************************/
-public class SObjectMetadata {
+public virtual class SObjectMetadata {
 
     // Aura-enabled member variables
     @AuraEnabled public Boolean hasSubtypes                  {get; private set;}
@@ -19,6 +19,7 @@ public class SObjectMetadata {
     @AuraEnabled public Boolean isUndeletable                {get; private set;}
     @AuraEnabled public Boolean isUpdateable                 {get; private set;}
     @AuraEnabled public List<String> fieldNames              {get; private set;}
+    @AuraEnabled public List<String> fieldSetNames           {get; private set;}
     @AuraEnabled public String keyPrefix                     {get; private set;}
     @AuraEnabled public String label                         {get; private set;}
     @AuraEnabled public String labelPlural                   {get; private set;}
@@ -59,6 +60,7 @@ public class SObjectMetadata {
         this.localName       = this.getDescribe().getLocalName();
 
         this.setFields();
+        this.setFieldSets();
         this.setNamespace();
         this.setRecordTypes();
         this.setTabIcon();
@@ -90,6 +92,13 @@ public class SObjectMetadata {
             if(fieldDescribe.isNameField()) this.nameField = fieldDescribe.getName();
 
             this.fieldNames.add(fieldDescribe.getName());
+        }
+    }
+
+    private void setFieldSets() {
+        this.fieldSetNames = new List<String>();
+        for(Schema.FieldSet fieldSet : this.getDescribe().fieldSets.getMap().values()) {
+            this.fieldSetNames.add(fieldSet.getName());
         }
     }
 
@@ -126,7 +135,7 @@ public class SObjectMetadata {
         if(this.tabIcon == null && this.name == 'AssetRelationship') this.tabIcon = 'standard:asset_relationship';
     }
 
-    public class RecordTypeMetadata {
+    public virtual class RecordTypeMetadata {
 
         // Aura-enabled member variables
         @AuraEnabled public Boolean isActive                   {get; private set;}

--- a/src/classes/SObjectMetadata.cls
+++ b/src/classes/SObjectMetadata.cls
@@ -1,5 +1,5 @@
 /*************************************************************************************************
-* This file is part of the SimpleMetadata project, released under the MIT License.              *
+* This file is part of the SimpleMetadata project, released under the MIT License.               *
 * See LICENSE file or go to https://github.com/jongpie/SimpleMetadata for full license details.  *
 *************************************************************************************************/
 public virtual class SObjectMetadata {

--- a/src/package.xml
+++ b/src/package.xml
@@ -2,6 +2,7 @@
 <Package xmlns="http://soap.sforce.com/2006/04/metadata">
 	<types>
 		<members>FieldMetadata</members>
+		<members>FieldSetMetadata</members>
 		<members>SObjectMetadata</members>
 		<name>ApexClass</name>
 	</types>


### PR DESCRIPTION
Added another class, FieldSetMetadata. This returns the info from a [Field Set](https://developer.salesforce.com/docs/atlas.en-us.apexcode.meta/apexcode/apex_methods_system_fieldsets_describe.htm), as well as 
- Local Name for field sets (something that is not provided natively in Apex)
- An instance of SObjectMetadata for the field set's SObject Type
- FieldSetMemberMetadata returns FieldMetadata for the last field in the field path. For example, if you add the field CreatedBy.Email to your field set,  then an instance of FieldMetadata would be returned for the field User.Email.